### PR TITLE
Add exclusion for .iml files created by IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ nbactions.xml
 #################
 
 .idea
+*.iml


### PR DESCRIPTION
Because it's what IntelliJ wants to do.