### PR TITLE
Bumping Java version to 1.8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/parallax/client/cloudsession/CloudSessionVersion.java
+++ b/src/main/java/com/parallax/client/cloudsession/CloudSessionVersion.java
@@ -1,0 +1,18 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.parallax.client.cloudsession;
+
+/**
+ * Maintain application version number here
+ * 
+ * @author Jim Ewald
+ * 
+ */
+public class CloudSessionVersion {
+    
+    static final String Version = "1.2.0";
+    
+}


### PR DESCRIPTION
Oracle has deprecated Java 1.7. Java 1.8 has long-term support for another 2-3 years.